### PR TITLE
feat: update manifest to include outbound access configurations for billing services

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -144,6 +144,20 @@
       }
     },
     {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "billing.weni.ai",
+        "path": "*"
+      }
+    },
+    {
+      "name": "outbound-access",
+      "attrs": {
+        "host": "billing.stg.cloud.weni.ai",
+        "path": "*"
+      }
+    },
+    {
       "name": "colossus-fire-event"
     },
     {


### PR DESCRIPTION
**What**
Add outbound access policies for the billing service hosts (billing.weni.ai and billing.stg.cloud.weni.ai) in manifest.json.
**Why**
Proxy requests from the frontend to the IO backend for the billing service were failing because the VTEX IO platform blocks external HTTP requests that are not explicitly declared as outbound access in the manifest. Without these entries, the runtime rejects the outgoing connections to the billing API, resulting in errors on the proxy route.