### PR TITLE
feat: add CancelAction and License Manager policies for OMS operations

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -174,6 +174,33 @@
     },
     {
       "name": "Get_Account_By_Identifier"
+    },
+    {
+      "name": "ManterFormularioProdutoSku"
+    },
+    {
+      "name": "Marca.aspx"
+    },
+    {
+      "name": "Sku.aspx"
+    },
+    {
+      "name": "AcessaTodosPedidos"
+    },
+    {
+      "name": "CancelaPedidos"
+    },
+    {
+      "name": "CancelAction"
+    },
+    {
+      "name": "SaveOrderFormConfiguration"
+    },
+    {
+      "name": "GetOrderForm"
+    },
+    {
+      "name": "ADMIN_DS"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"


### PR DESCRIPTION
**What:**
Added License Manager policies to manifest.json, including CancelAction, CancelaPedidos, AcessaTodosPedidos, ManterFormularioProdutoSku, Marca.aspx, Sku.aspx, SaveOrderFormConfiguration, GetOrderForm, and ADMIN_DS.
**Why:** 
The app requires License Manager permissions to perform write operations via OMS (such as order cancellation). The CancelAction policy was the missing piece for the app token to be recognized by the OMS backend, resolving the 403 Forbidden error on cancel order calls.