### PR TITLE
feat: add view-seller License Manager policy for seller listing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -182,6 +182,9 @@
       "name": "Marca.aspx"
     },
     {
+      "name": "view-seller"
+    },
+    {
       "name": "Sku.aspx"
     },
     {


### PR DESCRIPTION
**What:** 
Added view-seller License Manager policy to manifest.json to authorize the app to access seller data via the VTEX Sellers API.

**Why:** 
The proxy endpoint needs permission to list sellers from the account. Without this policy, requests to seller-related endpoints are rejected with 403 Forbidden by the VTEX backend.